### PR TITLE
Nix flake で他環境へのワンコマンド配布対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Thumbs.db
 # Build artifacts
 dist/
 build/
+
+# Nix
+/result
+/result-*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kamiriku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  description = "todo_cli - Terminal-first todo CLI with interactive TUI (Bubbletea + SQLite)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        todo-cli = pkgs.buildGoModule {
+          pname = "todo_cli";
+          version = "0.1.0";
+
+          src = ./.;
+
+          vendorHash = "sha256-y4GapGCQX5G2Ud8Zp4sRPtyGdWO5w++xylCnKglKuIw=";
+
+          subPackages = [
+            "cmd/todo"
+            "cmd/tb"
+            "cmd/td"
+          ];
+
+          env.CGO_ENABLED = "0";
+
+          ldflags = [ "-s" "-w" ];
+
+          meta = with pkgs.lib; {
+            description = "Terminal-first todo CLI with interactive TUI";
+            homepage = "https://github.com/kamiriku/todo_cli";
+            license = licenses.mit;
+            mainProgram = "todo";
+            platforms = platforms.unix;
+          };
+        };
+      in
+      {
+        packages = {
+          default = todo-cli;
+          todo_cli = todo-cli;
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${todo-cli}/bin/todo";
+          };
+          todo = {
+            type = "app";
+            program = "${todo-cli}/bin/todo";
+          };
+          tb = {
+            type = "app";
+            program = "${todo-cli}/bin/tb";
+          };
+          td = {
+            type = "app";
+            program = "${todo-cli}/bin/td";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            gopls
+            gotools
+            golangci-lint
+            gnumake
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary

- `flake.nix` を追加し、Nix が入ってる環境であれば `nix run github:karimiku/todo_cli` だけで `todo` / `tb` / `td` をビルド・実行できるようにした
- 配布の前提として `LICENSE` (MIT) を追加（無いと法的に他人がコピー不可で、nixpkgs にも載せられない）
- `nix build` が生成する `/result` シンボリックリンクを `.gitignore` に追加

## なぜ

Go製CLIの配布で「相手のマシンに即届ける」最短ルートとして、まず Nix flake から整備する。今後 GoReleaser + Homebrew tap を足せば配布範囲を広げられるが、第一歩として依存が無く決定論的に動く Nix を選択。

## flake.nix の構成

- `buildGoModule` で `cmd/todo`, `cmd/tb`, `cmd/td` を `subPackages` 指定でビルド
- `glebarez/sqlite` が pure Go なので `CGO_ENABLED=0`
- `ldflags = [ "-s" "-w" ]` でバイナリを strip
- `apps.{default,todo,tb,td}` を公開（`nix run .#tb` 等で個別起動可能）
- `devShells.default` に go / gopls / gotools / golangci-lint / gnumake

## 動作確認

ローカル (Determinate Nix 3.19.0, darwin) で確認済み:

- [x] `nix build` が成功し `result/bin/{todo,tb,td}` が生成される
- [x] `nix run .#todo -- --help` がヘルプを出力
- [x] `nix run .#tb -- --help` / `nix run .#td -- --help` も動作
- [x] バイナリサイズ 各 ~15MB（strip 効いてる）

## Test plan

- [ ] 別環境（Linux x86_64 など）で `nix run github:karimiku/todo_cli/feature/add-nix-flake` を試す
- [ ] `nix flake check` がエラーなく通る
- [ ] 既存の `make build` / `make test` / `make ci` が引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)